### PR TITLE
añadir tabla intermedia categoria_etiqueta y actualizar modelos y for…

### DIFF
--- a/codigo/controllers/EtiquetaController.php
+++ b/codigo/controllers/EtiquetaController.php
@@ -95,9 +95,9 @@ class EtiquetaController extends Controller
     {
         $model = $this->findModel($id);
 
-        return $this->render('view-categorias', [
+        return $this->render('//categoria/view-categorias', [
             'model' => $model,
-            'categorias' => $model->getCategorias(),
+            'categorias' => $model->getCategorias()->all(),
         ]);
     }
 

--- a/codigo/models/Categoria.php
+++ b/codigo/models/Categoria.php
@@ -61,4 +61,15 @@ class Categoria extends ActiveRecord
     {
         return $this->hasOne(self::className(), ['id' => 'id_padre']);
     }
+
+    /**
+     * Relación con las etiquetas asociadas a la categoría.
+     *
+     * @return ActiveQuery
+     */
+    public function getEtiquetas()
+    {
+        return $this->hasMany(Etiqueta::className(), ['id' => 'id_etiqueta'])
+                    ->viaTable('categoria_etiqueta', ['id_categoria' => 'id']);
+    }
 }

--- a/codigo/models/Etiqueta.php
+++ b/codigo/models/Etiqueta.php
@@ -44,26 +44,17 @@ class Etiqueta extends ActiveRecord
      */
     public function canBeDeleted()
     {
-        return $this->getCategorias()->count() === 0 && $this->getAlertas()->count() === 0;
+        return $this->getCategorias()->count() === 0;
     }
 
     /**
-     * Relación con la tabla de categorías.
+     * Relación con las categorías asociadas a la etiqueta.
      *
      * @return ActiveQuery
      */
     public function getCategorias()
     {
-        return $this->hasMany(Categoria::className(), ['id_etiqueta' => 'id']);
-    }
-
-    /**
-     * Relación con la tabla de alertas.
-     *
-     * @return ActiveQuery
-     */
-    public function getAlertas()
-    {
-        return $this->hasMany(Alerta::className(), ['id_etiqueta' => 'id']);
+        return $this->hasMany(Categoria::className(), ['id' => 'id_categoria'])
+                    ->viaTable('categoria_etiqueta', ['id_etiqueta' => 'id']);
     }
 }

--- a/codigo/views/categoria/view-categorias.php
+++ b/codigo/views/categoria/view-categorias.php
@@ -1,0 +1,40 @@
+<?php
+use yii\helpers\Html;
+use yii\grid\GridView;
+
+$this->title = 'Categorías vinculadas a la etiqueta: ' . Html::encode($model->nombre);
+$this->params['breadcrumbs'][] = ['label' => 'Etiquetas', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="categoria-view-categorias">
+    <h1><?= Html::encode($this->title) ?></h1>
+
+    <p>
+        <?= Html::a('Volver a Etiquetas', ['etiqueta/index'], ['class' => 'btn btn-primary']) ?>
+    </p>
+
+    <?= GridView::widget([
+        'dataProvider' => new \yii\data\ArrayDataProvider([
+            'allModels' => $categorias,
+            'pagination' => [
+                'pageSize' => 10,
+            ],
+        ]),
+        'columns' => [
+            ['class' => 'yii\grid\SerialColumn'],
+            'id',
+            'nombre',
+            'descripcion',
+            [
+                'class' => 'yii\grid\ActionColumn',
+                'template' => '{view}',
+                'buttons' => [
+                    'view' => function ($url, $model) {
+                        return Html::a('Ver', ['categoria/view', 'id' => $model->id], ['class' => 'btn btn-info btn-sm']);
+                    },
+                ],
+            ],
+        ],
+    ]); ?>
+</div>

--- a/sql/db_proyecto_c_AlertasEtiquetasCategorias.sql
+++ b/sql/db_proyecto_c_AlertasEtiquetasCategorias.sql
@@ -68,6 +68,28 @@ CREATE TABLE `categorias` (
   `id_etiqueta` int(11) DEFAULT NULL COMMENT 'ID de la etiqueta relacionada'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
+--
+-- Volcado de datos para la tabla `categorias`
+--
+
+INSERT INTO `categorias` (`id`, `nombre`, `descripcion`, `id_padre`, `id_etiqueta`) VALUES
+(1, 'Catástrofes naturales', 'Eventos como terremotos, incendios forestales, huracanes, etc.', NULL, NULL),
+(2, 'Emergencias de salud pública', 'Pandemias y brotes de enfermedades infecciosas.', NULL, NULL),
+(3, 'Terrorismo', 'Amenazas de bomba, tiroteos y otras actividades terroristas.', NULL, NULL),
+(4, 'Accidentes industriales', 'Explosiones, vertidos de sustancias químicas y fallos estructurales.', NULL, NULL),
+(5, 'Emergencias civiles', 'Órdenes de evacuación, disturbios civiles y otras emergencias.', NULL, NULL);
+
+-- --------------------------------------------------------
+
+--
+-- Estructura de tabla para la tabla `categoria_etiqueta`
+--
+
+CREATE TABLE `categoria_etiqueta` (
+  `id_categoria` int(11) NOT NULL,
+  `id_etiqueta` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
 -- --------------------------------------------------------
 
 --
@@ -170,6 +192,13 @@ ALTER TABLE `categorias`
   ADD KEY `id_etiqueta` (`id_etiqueta`);
 
 --
+-- Indices de la tabla `categoria_etiqueta`
+--
+ALTER TABLE `categoria_etiqueta`
+  ADD PRIMARY KEY (`id_categoria`,`id_etiqueta`),
+  ADD KEY `id_etiqueta` (`id_etiqueta`);
+
+--
 -- Indices de la tabla `etiquetas`
 --
 ALTER TABLE `etiquetas`
@@ -226,6 +255,13 @@ ALTER TABLE `alertas`
 ALTER TABLE `categorias`
   ADD CONSTRAINT `categorias_ibfk_1` FOREIGN KEY (`id_padre`) REFERENCES `categorias` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `categorias_ibfk_2` FOREIGN KEY (`id_etiqueta`) REFERENCES `etiquetas` (`id`) ON DELETE SET NULL;
+
+--
+-- Filtros para la tabla `categoria_etiqueta`
+--
+ALTER TABLE `categoria_etiqueta`
+  ADD CONSTRAINT `categoria_etiqueta_ibfk_1` FOREIGN KEY (`id_categoria`) REFERENCES `categorias` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `categoria_etiqueta_ibfk_2` FOREIGN KEY (`id_etiqueta`) REFERENCES `etiquetas` (`id`) ON DELETE CASCADE;
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;


### PR DESCRIPTION
Actualización de la base de datos:

Creación de la tabla intermedia categoria_etiqueta para gestionar la relación muchos a muchos entre categorías y etiquetas.
Modificación de la columna id_etiqueta en la tabla alertas para convertirla en id_categoria, reflejando correctamente la relación de las alertas con las categorías.
Actualización de los modelos:

Modelo Categoria:
Añadida la propiedad getEtiquetas para acceder a las etiquetas asociadas a través de la tabla intermedia categoria_etiqueta.
Modelo Etiqueta:
Actualizada la propiedad getCategorias para manejar la relación con las categorías a través de la tabla intermedia categoria_etiqueta.
Formulario de Categorías (views/categoria/_form.php):

Añadido un campo etiquetasSeleccionadas que permite seleccionar múltiples etiquetas al crear o editar una categoría.
Actualización del modelo Categoria para gestionar las relaciones entre categorías y etiquetas:
Guardar las etiquetas seleccionadas en la tabla intermedia al guardar o actualizar una categoría.
Cargar automáticamente las etiquetas asociadas al editar una categoría.
